### PR TITLE
Create lego_body

### DIFF
--- a/android/app/src/main/java/org/openbot/autopilot/AutopilotFragment.java
+++ b/android/app/src/main/java/org/openbot/autopilot/AutopilotFragment.java
@@ -349,13 +349,19 @@ public class AutopilotFragment extends CameraFragment {
     binding.autoSwitch.setChecked(b);
     binding.controllerContainer.controlMode.setEnabled(!b);
     binding.controllerContainer.driveMode.setEnabled(!b);
-    binding.controllerContainer.speedInfo.setEnabled(!b);
+    binding.controllerContainer.speedMode.setEnabled(!b);
 
     binding.controllerContainer.controlMode.setAlpha(b ? 0.5f : 1f);
     binding.controllerContainer.driveMode.setAlpha(b ? 0.5f : 1f);
     binding.controllerContainer.speedMode.setAlpha(b ? 0.5f : 1f);
 
-    if (!b) handler.postDelayed(() -> vehicle.setControl(0, 0), 500);
+    if (!b) {
+      setSpeedMode(Enums.SpeedMode.getByID(preferencesManager.getSpeedMode()));
+      handler.postDelayed(() -> vehicle.setControl(0, 0), 500);
+    } else {
+      binding.controllerContainer.speedMode.setImageResource(R.drawable.ic_speed_high);
+      vehicle.setSpeedMultiplier(Enums.SpeedMode.FAST.getValue());
+    }
   }
 
   private long frameNum = 0;
@@ -459,7 +465,7 @@ public class AutopilotFragment extends CameraFragment {
   }
 
   private void setSpeedMode(Enums.SpeedMode speedMode) {
-    if (speedMode != null) {
+    if (speedMode != null && !binding.autoSwitch.isChecked()) {
       switch (speedMode) {
         case SLOW:
           binding.controllerContainer.speedMode.setImageResource(R.drawable.ic_speed_low);

--- a/android/app/src/main/java/org/openbot/autopilot/AutopilotFragment.java
+++ b/android/app/src/main/java/org/openbot/autopilot/AutopilotFragment.java
@@ -10,6 +10,7 @@ import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.SystemClock;
 import android.util.TypedValue;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -292,6 +293,17 @@ public class AutopilotFragment extends CameraFragment {
             R.string.speedInfo,
             String.format(
                 Locale.US, "%3.0f,%3.0f", vehicle.getLeftWheelRpm(), vehicle.getRightWheelRpm())));
+  }
+
+  @Override
+  protected void processKeyEvent(KeyEvent keyCode) {
+    if (binding.autoSwitch.isChecked()
+        && (keyCode.getKeyCode() == KeyEvent.KEYCODE_BUTTON_THUMBL
+            || keyCode.getKeyCode() == KeyEvent.KEYCODE_BUTTON_THUMBR)) {
+      audioPlayer.playFromString("Autopilot active. Cannot change speed mode.");
+    } else {
+      super.processKeyEvent(keyCode);
+    }
   }
 
   @Override

--- a/android/app/src/main/java/org/openbot/common/ControlsFragment.java
+++ b/android/app/src/main/java/org/openbot/common/ControlsFragment.java
@@ -172,7 +172,7 @@ public abstract class ControlsFragment extends Fragment implements ServerListene
     handlePhoneControllerEvents();
   }
 
-  private void processKeyEvent(KeyEvent keyCode) {
+  protected void processKeyEvent(KeyEvent keyCode) {
     if (Enums.ControlMode.getByID(preferencesManager.getControlMode())
         == Enums.ControlMode.GAMEPAD) {
       switch (keyCode.getKeyCode()) {
@@ -209,6 +209,7 @@ public abstract class ControlsFragment extends Fragment implements ServerListene
           break;
         case KeyEvent.KEYCODE_BUTTON_THUMBR:
           processControllerKeyData(Constants.CMD_SPEED_UP);
+
           audioPlayer.playSpeedMode(
               voice, Enums.SpeedMode.getByID(preferencesManager.getSpeedMode()));
           break;

--- a/android/app/src/main/java/org/openbot/objectNav/ObjectNavFragment.java
+++ b/android/app/src/main/java/org/openbot/objectNav/ObjectNavFragment.java
@@ -388,7 +388,7 @@ public class ObjectNavFragment extends CameraFragment {
 
     binding.controllerContainer.controlMode.setEnabled(!b);
     binding.controllerContainer.driveMode.setEnabled(!b);
-    binding.controllerContainer.speedInfo.setEnabled(!b);
+    binding.controllerContainer.speedMode.setEnabled(!b);
 
     binding.controllerContainer.controlMode.setAlpha(b ? 0.5f : 1f);
     binding.controllerContainer.driveMode.setAlpha(b ? 0.5f : 1f);

--- a/policy/README.md
+++ b/policy/README.md
@@ -16,7 +16,7 @@ You first need to setup your training environment.
 
 ## Dependencies
 
-We recommend to create a conda environment for OpenBot. Instructions on installing conda can be found [here](https://docs.conda.io/projects/conda/en/latest/user-guide/install/). The easiest way to create a new environment with all dependencies is to use one of the provided environment files. Make sure you are in the folder `policy` within your local OpenBot repository. Based on your operating system, run the corresponding command:
+We recommend to create a conda environment for OpenBot. Instructions on installing conda can be found [here](https://docs.conda.io/projects/conda/en/latest/user-guide/install/). The easiest way to create a new environment with all dependencies is to use one of the provided environment files. On Windows, you will also need to install [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). Make sure you are in the folder `policy` within your local OpenBot repository. Based on your operating system, run the corresponding command:
 
 - **MacOS**: `conda env create -f environment_mac.yml`
 - **Windows**: `conda env create -f environment_win.yml`


### PR DESCRIPTION
Dear @thias15 

Please create the folder using the name "XL_lego_body" as it describes beter what is inside this folder.
There are 2 body top types and 1 body bottom: 

1. An increased height (XL) short version with front bumper and sleak top (no lego compatible)
2. An increased height (XL) short version with front bumper and lego compatible top
3. A short version body bottom with front bumper matching the 1-2 top types.

Please find attached the readme file along with the STL files.

[OpenBot - XL lego.zip](https://github.com/Christos-Ps/OpenBot/files/11115540/OpenBot.-.XL.lego.zip)
[OpenBot DIY - XL lego - Readme.docx](https://github.com/Christos-Ps/OpenBot/files/11115612/OpenBot.DIY.-.XL.lego.-.Readme.docx)
